### PR TITLE
[CI] Add Python 3.9 support

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os:  [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
And would you consider dropping 3.5 support, since it is after EOL?