### PR TITLE
Simplify collections manipulation in code

### DIFF
--- a/ankipandas/_columns.py
+++ b/ankipandas/_columns.py
@@ -21,14 +21,12 @@ fields_df = pd.read_csv(fields_file)
 #: nid.
 table2index = {"cards": "cid", "notes": "nid", "revs": "rid"}
 
-our_tables = sorted(list(tables_ours2anki.keys()))
+our_tables = sorted(tables_ours2anki)
 our_columns = {
     table: sorted(
-        list(
-            fields_df[(fields_df["Table"] == table) & fields_df["Default"]][
-                "Column"
-            ].unique()
-        )
+        fields_df[(fields_df["Table"] == table) & fields_df["Default"]][
+            "Column"
+        ].unique()
     )
     for table in our_tables
 }

--- a/ankipandas/ankidf.py
+++ b/ankipandas/ankidf.py
@@ -1400,14 +1400,14 @@ class AnkiDataFrame(pd.DataFrame):
                 )
             )
 
-        mids = list(set(map(lambda x: nid2mid[x], nid)))
+        mids = {nid2mid[x] for x in nid}
         if len(mids) >= 2:
             raise ValueError(
                 "It is only supported to add cards for notes of the same model"
                 ", but you're trying to add cards for notes of "
                 "models: {}".format(", ".join(map(str, mids)))
             )
-        mid = mids[0]
+        mid = mids.pop()
 
         # fixme: should use function from ankipandas.raw
         available_ords = raw.get_mid2templateords(self.db)[mid]
@@ -1659,11 +1659,11 @@ class AnkiDataFrame(pd.DataFrame):
                     "Unknown fields: {}".format(", ".join(unknown_fields))
                 )
             field_key2field = {
-                key: list(map(lambda d: d.get(key), nflds))
+                key: [d.get(key) for d in nflds]
                 for key in field_keys
             }
         elif is_list_list_like(nflds):
-            n_fields = list(set(map(len, nflds)))
+            n_fields = list({len(x) for x in nflds})
             n_notes = len(nflds)
             if not (len(n_fields) == 1 and n_fields[0] == len(field_keys)):
                 raise ValueError(
@@ -1674,11 +1674,11 @@ class AnkiDataFrame(pd.DataFrame):
                     )
                 )
             field_key2field = {
-                field_keys[i]: list(map(lambda x: x[i], nflds))
-                for i in range(len(field_keys))
+                field_key: [x[i] for x in nflds]
+                for i, field_key in enumerate(field_keys)
             }
         elif is_dict_list_like(nflds):
-            lengths = list(set(map(len, nflds.values())))
+            lengths = list({len(x) for x in  nflds.values()})
             if len(lengths) >= 2:
                 raise ValueError(
                     "Inconsistent number of "

--- a/ankipandas/ankidf.py
+++ b/ankipandas/ankidf.py
@@ -650,11 +650,9 @@ class AnkiDataFrame(pd.DataFrame):
             )
         else:
             return sorted(
-                list(
-                    {
-                        item for lst in self["ntags"].tolist() for item in lst
-                    }
-                )
+                {
+                    item for lst in self["ntags"].tolist() for item in lst
+                }
             )
 
     def list_decks(self) -> List[str]:
@@ -665,7 +663,7 @@ class AnkiDataFrame(pd.DataFrame):
                 "or merge it into your table."
             )
         else:
-            decks = sorted(list(self["cdeck"].unique()))
+            decks = sorted(self["cdeck"].unique())
             if "" in decks:
                 decks.remove("")
             return decks
@@ -677,7 +675,7 @@ class AnkiDataFrame(pd.DataFrame):
                 "Model column 'nmodel' not present. Either use the notes table"
                 " or merge it into your table."
             )
-        return sorted(list(self["nmodel"].unique()))
+        return sorted(self["nmodel"].unique())
 
     def has_tag(self, tags: Optional[Union[Iterable[str], str]] = None):
         """ Checks whether row has a certain tag ('ntags' column).
@@ -773,7 +771,7 @@ class AnkiDataFrame(pd.DataFrame):
             return
 
         def _add_tags(other):
-            return other + sorted(list(set(tags) - set(other)))
+            return other + sorted(set(tags) - set(other))
 
         self["ntags"] = self["ntags"].apply(_add_tags)
 
@@ -838,9 +836,7 @@ class AnkiDataFrame(pd.DataFrame):
         if self._fields_format == "columns":
             self_sf = self.fields_as_list(inplace=False, force=_force)
 
-        cols = sorted(
-            list(set(self_sf.columns).intersection(set(other.columns)))
-        )
+        cols = sorted(set(self_sf.columns) & set(other.columns))
 
         other_nids = set(other.index)
         inters = set(self_sf.index).intersection(other_nids)
@@ -881,7 +877,7 @@ class AnkiDataFrame(pd.DataFrame):
             inters = inters.intersection(
                 self[self.was_modified(other=other, _force=_force)].index
             )
-        inters = sorted(list(inters))
+        inters = sorted(inters)
         return pd.DataFrame(
             self.loc[inters, cols].values != other.loc[inters, cols].values,
             index=self.loc[inters].index,
@@ -935,7 +931,7 @@ class AnkiDataFrame(pd.DataFrame):
             other_ids = set(self.col._get_original_item(self._anki_table).id)
 
         deleted_indices = other_ids - set(self.index)
-        return sorted(list(deleted_indices))
+        return sorted(deleted_indices)
 
     # Update modification stamps and similar
     # ==========================================================================
@@ -1394,7 +1390,7 @@ class AnkiDataFrame(pd.DataFrame):
         # --- Ord ---
 
         nid2mid = raw.get_nid2mid(self.db)
-        missing_nids = sorted(list(set(nid) - set(nid2mid.keys())))
+        missing_nids = sorted(set(nid) - set(nid2mid))
         if missing_nids:
             raise ValueError(
                 "The following note IDs (nid) can't be found in the notes "
@@ -1425,7 +1421,7 @@ class AnkiDataFrame(pd.DataFrame):
             raise ValueError(
                 "Unknown type for cord specifiation: {}".format(type(cord))
             )
-        not_available = sorted(list(set(cord) - set(available_ords)))
+        not_available = sorted(set(cord) - set(available_ords))
         if not_available:
             raise ValueError(
                 "The following templates are not available for notes of "
@@ -1446,7 +1442,7 @@ class AnkiDataFrame(pd.DataFrame):
         else:
             raise ValueError("Unknown format for cdeck: {}".format(type(cdeck)))
         unknown_decks = sorted(
-            list(set(cdeck) - set(raw.get_did2deck(self.db).values()))
+            set(cdeck) - set(raw.get_did2deck(self.db).values())
         )
         if unknown_decks:
             raise ValueError(
@@ -1476,7 +1472,7 @@ class AnkiDataFrame(pd.DataFrame):
                     )
                 )
             if options is not None:
-                invalid = sorted(list(set(inpt) - set(options)))
+                invalid = sorted(set(inpt) - set(options))
                 if invalid:
                     raise ValueError(
                         "The following values are no valid "
@@ -1659,7 +1655,7 @@ class AnkiDataFrame(pd.DataFrame):
             specified_fields = set(
                 flatten_list_list(list(map(lambda d: list(d.keys()), nflds)))
             )
-            unknown_fields = sorted(list(specified_fields - set(field_keys)))
+            unknown_fields = sorted(specified_fields - set(field_keys))
             if unknown_fields:
                 raise ValueError(
                     "Unknown fields: {}".format(", ".join(unknown_fields))
@@ -1722,7 +1718,7 @@ class AnkiDataFrame(pd.DataFrame):
         else:
             nid = self._get_ids(n=n_notes)
 
-        already_present = sorted(list(set(nid).intersection(set(self.index))))
+        already_present = sorted(set(nid) & set(self.index))
         if already_present:
             raise ValueError(
                 "The following note IDs (nid) are "
@@ -1756,9 +1752,7 @@ class AnkiDataFrame(pd.DataFrame):
         else:
             nguid = [generate_guid() for _ in range(n_notes)]
 
-        existing_guids = sorted(
-            list(set(nguid).intersection(self["nguid"].unique()))
-        )
+        existing_guids = sorted(set(nguid) & set(self["nguid"].unique()))
         if existing_guids:
             raise ValueError(
                 "The following globally unique IDs (guid) are already"

--- a/ankipandas/ankidf.py
+++ b/ankipandas/ankidf.py
@@ -14,7 +14,7 @@ import ankipandas.raw as raw
 import ankipandas.util.dataframe
 from ankipandas.util.dataframe import replace_df_inplace
 import ankipandas._columns as _columns
-from ankipandas.util.misc import invert_dict, flatten_list_list
+from ankipandas.util.misc import invert_dict
 from ankipandas.util.log import log
 from ankipandas.util.checksum import field_checksum
 from ankipandas.util.guid import guid as generate_guid
@@ -1652,9 +1652,7 @@ class AnkiDataFrame(pd.DataFrame):
 
         if is_list_dict_like(nflds):
             n_notes = len(nflds)
-            specified_fields = set(
-                flatten_list_list(list(map(lambda d: list(d.keys()), nflds)))
-            )
+            specified_fields = {key for nfld in nflds for key in nfld}
             unknown_fields = sorted(specified_fields - set(field_keys))
             if unknown_fields:
                 raise ValueError(

--- a/ankipandas/ankidf.py
+++ b/ankipandas/ankidf.py
@@ -836,7 +836,7 @@ class AnkiDataFrame(pd.DataFrame):
         if self._fields_format == "columns":
             self_sf = self.fields_as_list(inplace=False, force=_force)
 
-        cols = sorted(set(self_sf.columns) & set(other.columns))
+        cols = sorted(set(self_sf.columns).intersection(set(other.columns)))
 
         other_nids = set(other.index)
         inters = set(self_sf.index).intersection(other_nids)
@@ -1716,7 +1716,7 @@ class AnkiDataFrame(pd.DataFrame):
         else:
             nid = self._get_ids(n=n_notes)
 
-        already_present = sorted(set(nid) & set(self.index))
+        already_present = sorted(set(nid).intersection(set(self.index)))
         if already_present:
             raise ValueError(
                 "The following note IDs (nid) are "

--- a/ankipandas/ankidf.py
+++ b/ankipandas/ankidf.py
@@ -1678,15 +1678,15 @@ class AnkiDataFrame(pd.DataFrame):
                 for i, field_key in enumerate(field_keys)
             }
         elif is_dict_list_like(nflds):
-            lengths = list({len(x) for x in  nflds.values()})
+            lengths = {len(x) for x in  nflds.values()}
             if len(lengths) >= 2:
                 raise ValueError(
                     "Inconsistent number of "
                     "fields: {}".format(", ".join(map(str, lengths)))
                 )
-            elif len(lengths) == 0:
+            elif not lengths:
                 raise ValueError("Are you trying to add zero notes?")
-            n_notes = lengths[0]
+            n_notes = lengths.pop()
             field_key2field = copy.deepcopy(nflds)
             for key in field_keys:
                 if key not in field_key2field:

--- a/ankipandas/ankidf.py
+++ b/ankipandas/ankidf.py
@@ -1642,7 +1642,7 @@ class AnkiDataFrame(pd.DataFrame):
         # --- Model ---
 
         model2mid = raw.get_model2mid(self.db)
-        if nmodel not in model2mid.keys():
+        if nmodel not in model2mid:
             raise ValueError(
                 f"No model of with name '{nmodel}' exists."
             )

--- a/ankipandas/collection.py
+++ b/ankipandas/collection.py
@@ -232,11 +232,11 @@ class Collection:
         )
         if raw.get_db_version(self.db) == 0:
             for key in info_updates:
-                assert key in info.keys()
+                assert key in info
             info.update(info_updates)
         elif raw.get_db_version(self.db) == 1:
-            assert len(list(info.keys())) == 1
-            first_key = list(info.keys())[0]
+            assert len(info) == 1
+            first_key = list(info)[0]
             info[first_key].update(info_updates)
         # fixme: this currently doesn't work. In the new db structure there's
         #   a tags table instead of a field, but it doesn't seem to be

--- a/ankipandas/paths.py
+++ b/ankipandas/paths.py
@@ -159,13 +159,13 @@ def find_db(
                 "Found databases for more than one user: {}. Please specify "
                 "the user.".format(", ".join(found))
             )
-        elif len(found) == 0:
+        elif not found:
             raise ValueError(
                 "No database found. You might increase the search depth or "
                 "specify search paths to find more."
             )
         else:
-            found = list(found.values())[0]
+            found = found.popitem()[1]
     if len(found) >= 2:
         raise ValueError(
             "Found more than one database belonging to user {} at {}".format(

--- a/ankipandas/paths.py
+++ b/ankipandas/paths.py
@@ -154,12 +154,12 @@ def find_db(
             )
         found = found[user]
     else:
-        if len(found.keys()) >= 2:
+        if len(found) >= 2:
             raise ValueError(
                 "Found databases for more than one user: {}. Please specify "
-                "the user.".format(", ".join(found.keys()))
+                "the user.".format(", ".join(found))
             )
-        elif len(found.keys()) == 0:
+        elif len(found) == 0:
             raise ValueError(
                 "No database found. You might increase the search depth or "
                 "specify search paths to find more."

--- a/ankipandas/raw.py
+++ b/ankipandas/raw.py
@@ -99,7 +99,7 @@ def get_empty_table(table: str) -> pd.DataFrame:
 
 
 def _interpret_json_val(val):
-    if isinstance(val, str) and len(val) >= 1:
+    if isinstance(val, str) and val:
         try:
             return json.loads(val)
         except json.decoder.JSONDecodeError:

--- a/ankipandas/test/test_ankidf.py
+++ b/ankipandas/test/test_ankidf.py
@@ -242,14 +242,14 @@ class TestAnkiDF(unittest.TestCase):
             "cards": set(self.cards.mid),
             "revs": set(self.revs.mid),
         }
-        mids = set(raw.get_mid2model(self.db).keys())
+        mids = set(raw.get_mid2model(self.db))
         for table, mids2 in mids2s.items():
             with self.subTest(table=table):
                 self.assertTrue(mids2.issubset(mids))
 
     def test_dids(self):
         did2s = {"cards": set(self.cards.did), "revs": set(self.revs.did)}
-        dids = set(raw.get_did2deck(self.db).keys())
+        dids = set(raw.get_did2deck(self.db))
         for table, dids2 in did2s.items():
             with self.subTest(table=table):
                 self.assertTrue(dids2.issubset(dids))
@@ -757,7 +757,7 @@ class TestAnkiDF(unittest.TestCase):
         empty = self.necards()
         empty2 = self.necards()
 
-        nid = list(raw.get_nid2mid(self.db).keys())[0]
+        nid = list(raw.get_nid2mid(self.db))[0]
         deck = list(raw.get_did2deck(self.db).values())[0]
 
         init_dict2 = dict(

--- a/ankipandas/test/test_ankidf.py
+++ b/ankipandas/test/test_ankidf.py
@@ -101,7 +101,7 @@ class TestAnkiDF(unittest.TestCase):
             self.assertEqual(len(eadf), 0)
             adf = self.table2adf[table]
             self.assertListEqual(
-                sorted(list(adf.columns)), sorted(list(eadf.columns))
+                sorted(adf.columns), sorted(eadf.columns)
             )
 
     def test_tags(self):
@@ -118,20 +118,20 @@ class TestAnkiDF(unittest.TestCase):
         cards = self.cards
         self.assertGreater(len(cards), 11)
         self.assertEqual(
-            list(sorted(cards.columns)), sorted(our_columns["cards"])
+            sorted(cards.columns), sorted(our_columns["cards"])
         )
 
     def test_notes(self):
         notes = self.notes
         self.assertGreater(len(notes), 6)
         self.assertEqual(
-            list(sorted(notes.columns)), sorted(our_columns["notes"])
+            sorted(notes.columns), sorted(our_columns["notes"])
         )
 
     def test_get_revs(self):
         revs = self.revs
         self.assertEqual(
-            list(sorted(revs.columns)), sorted(our_columns["revs"])
+            sorted(revs.columns), sorted(our_columns["revs"])
         )
         self.assertGreater(len(revs), 4)
 
@@ -141,21 +141,19 @@ class TestAnkiDF(unittest.TestCase):
     def test_merge_notes_cards(self):
         merged = self.ncards().merge_notes()
         self.assertListEqual(
-            sorted(list(merged.columns)),
-            sorted(list(set(our_columns["cards"]) | set(our_columns["notes"]))),
+            sorted(merged.columns),
+            sorted(set(our_columns["cards"]) | set(our_columns["notes"])),
         )
 
     def test_merge_notes_revs(self):
         merged = self.nrevs().merge_notes()
         self.assertListEqual(
-            sorted(list(merged.columns)),
+            sorted(merged.columns),
             sorted(
-                list(
-                    # Note: 'nid' is not a notes column.
-                    set(our_columns["revs"])
-                    | set(our_columns["notes"])
-                    | {"nid"}
-                )
+                # Note: 'nid' is not a notes column.
+                set(our_columns["revs"])
+                | set(our_columns["notes"])
+                | {"nid"}
             ),
         )
 
@@ -166,8 +164,8 @@ class TestAnkiDF(unittest.TestCase):
     def test_merge_cards(self):
         merged = self.nrevs().merge_cards()
         self.assertListEqual(
-            sorted(list(merged.columns)),
-            sorted(list(set(our_columns["revs"]) | set(our_columns["cards"]))),
+            sorted(merged.columns),
+            sorted(set(our_columns["revs"]) | set(our_columns["cards"])),
         )
 
     def test_merge_cards_raises(self):
@@ -265,7 +263,7 @@ class TestAnkiDF(unittest.TestCase):
         cols.remove("nflds")
         prefix = notes.fields_as_columns_prefix
         new_cols = [prefix + item for item in ["Front", "Back"]]
-        self.assertEqual(sorted(list(notes.columns)), sorted(cols + new_cols))
+        self.assertEqual(sorted(notes.columns), sorted(cols + new_cols))
 
     def test_fields_as_columns_x2(self):
         notes = self.nnotes()
@@ -282,7 +280,7 @@ class TestAnkiDF(unittest.TestCase):
         notes = notes.fields_as_columns().fields_as_list()
         self.assertEqual(list(flds), list(notes["nflds"].values))
         self.assertListEqual(
-            sorted(list(notes.columns)), sorted(our_columns["notes"])
+            sorted(notes.columns), sorted(our_columns["notes"])
         )
 
     def test_fields_as_list_x2(self):
@@ -991,7 +989,7 @@ class TestAnkiDF(unittest.TestCase):
                 )
                 self.assertListEqual(
                     sorted(adf.columns),
-                    sorted(list(set(df.index))),  # nid, cid appear twice
+                    sorted(set(df.index)),  # nid, cid appear twice
                 )
 
     def test_help(self):

--- a/ankipandas/test/test_ankidf.py
+++ b/ankipandas/test/test_ankidf.py
@@ -343,22 +343,24 @@ class TestAnkiDF(unittest.TestCase):
     def test_remove_tags(self):
         notes = self.nnotes()
         notes = notes.remove_tag(None)
-        self.assertEqual(list(set(map(tuple, notes["ntags"]))), [()])
+        self.assertEqual(list({tuple(x) for x in notes["ntags"]}), [()])
 
     def test_add_tags(self):
         notes = self.nnotes().remove_tag(None).add_tag("1145")
-        self.assertListEqual(list(set(map(tuple, notes["ntags"]))), [("1145",)])
+        self.assertListEqual(
+            list({tuple(x) for x in notes["ntags"]}), [("1145",)]
+        )
         notes.add_tag("abc", inplace=True)
         self.assertListEqual(
-            list(set(map(tuple, notes["ntags"]))), [("1145", "abc")]
+            list({tuple(x) for x in notes["ntags"]}), [("1145", "abc")]
         )
         notes.add_tag(["abc", "def"], inplace=True)
         self.assertListEqual(
-            list(set(map(tuple, notes["ntags"]))), [("1145", "abc", "def")]
+            list({tuple(x) for x in notes["ntags"]}), [("1145", "abc", "def")]
         )
         notes.add_tag([], inplace=True)
         self.assertListEqual(
-            list(set(map(tuple, notes["ntags"]))), [("1145", "abc", "def")]
+            list({tuple(x) for x in notes["ntags"]}), [("1145", "abc", "def")]
         )
 
     def test_has_tag(self):

--- a/ankipandas/test/test_paths.py
+++ b/ankipandas/test/test_paths.py
@@ -92,7 +92,7 @@ class TestFindDatabase(unittest.TestCase):
                 ).values()
                 for val in vals
             )
-            b = sorted(map(str, self.dbs[d]))
+            b = sorted(str(x) for x in self.dbs[d])
             self.assertListEqual(a, b)
 
     def test__find_database_filename(self):

--- a/ankipandas/test/test_paths.py
+++ b/ankipandas/test/test_paths.py
@@ -10,7 +10,6 @@ from randomfiletree import sample_random_elements, iterative_gaussian_tree
 
 # ours
 import ankipandas.paths as paths
-from ankipandas.util.misc import flatten_list_list
 from ankipandas.util.log import set_debug_log_level
 
 
@@ -85,16 +84,13 @@ class TestFindDatabase(unittest.TestCase):
     def test__find_database(self):
         for d in self.dirs:
             a = sorted(
-                map(
-                    str,
-                    flatten_list_list(
-                        paths._find_db(
-                            self.dirs[d].name,
-                            maxdepth=None,
-                            break_on_first=False,
-                        ).values()
-                    ),
-                )
+                str(val)
+                for vals in paths._find_db(
+                    self.dirs[d].name,
+                    maxdepth=None,
+                    break_on_first=False,
+                ).values()
+                for val in vals
             )
             b = sorted(map(str, self.dbs[d]))
             self.assertListEqual(a, b)

--- a/ankipandas/test/test_raw.py
+++ b/ankipandas/test/test_raw.py
@@ -246,10 +246,10 @@ class TestMergeDfs(unittest.TestCase):
             drop_columns=["id_add", "drop"],
         )
         self.assertListEqual(
-            sorted(list(df_merged.columns)),
+            sorted(df_merged.columns),
             ["_clash", "clash", "id_df", "value"],
         )
-        self.assertListEqual(sorted(list(df_merged["value"])), [4, 4, 4, 5, 6])
+        self.assertListEqual(sorted(df_merged["value"]), [4, 4, 4, 5, 6])
 
     def test_merge_dfs_prepend_all(self):
         df_merged = merge_dfs(
@@ -261,7 +261,7 @@ class TestMergeDfs(unittest.TestCase):
             prepend_clash_only=False,
         )
         self.assertListEqual(
-            sorted(list(df_merged.columns)),
+            sorted(df_merged.columns),
             ["_clash", "_drop", "_ignore", "_value", "clash", "id_df"],
         )
 
@@ -269,10 +269,10 @@ class TestMergeDfs(unittest.TestCase):
         df = copy.deepcopy(self.df)
         merge_dfs(df, self.df_add, id_df="id_df", id_add="id_add", inplace=True)
         self.assertListEqual(
-            sorted(list(df.columns)),
+            sorted(df.columns),
             ["clash_x", "clash_y", "drop", "id_df", "ignore", "value"],
         )
-        self.assertListEqual(sorted(list(df["value"])), [4, 4, 4, 5, 6])
+        self.assertListEqual(sorted(df["value"]), [4, 4, 4, 5, 6])
 
 
 if __name__ == "__main__":

--- a/ankipandas/util/misc.py
+++ b/ankipandas/util/misc.py
@@ -22,18 +22,6 @@ def invert_dict(dct: dict) -> dict:
     return {value: key for key, value in dct.items()}
 
 
-def flatten_list_list(lst: List[List[Any]]) -> List[Any]:
-    """ Takes a list of lists and returns a list of all elements.
-
-    Args:
-        lst: List of Lists
-
-    Returns:
-        list
-    """
-    return [item for sublist in lst for item in sublist]
-
-
 def nested_dict():
     """ This is very clever and stolen from
     https://stackoverflow.com/questions/16724788/

--- a/ankipandas/util/misc.py
+++ b/ankipandas/util/misc.py
@@ -17,7 +17,7 @@ def invert_dict(dct: dict) -> dict:
     """
     if not len(set(dct.values())) == len(dct.values()):
         print(dct)
-        print(sorted(list(dct.values())))
+        print(sorted(dct.values()))
         raise ValueError("Dictionary does not seem to be invertible.")
     return {value: key for key, value in dct.items()}
 


### PR DESCRIPTION
Several independent refactorings to simplify the manipulation of collections (lists, sets, dicts) in the code:

1. `sorted` takes `list` and returns `list`, no need to convert it explicitly on both ends 
2. the method `flatten_list_list` can be replaced by its content easily
3. change map to clearer comprehensions
4. `set & set` is more readable than `set.intersection(set)`
5. accessing a dict in list context uses `.keys()`

Please feel free to choose what you like.