### PR TITLE
Add build job, more declarative package metadata

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -4,32 +4,93 @@ on: [push, pull_request]
 
 jobs:
   build:
+    runs-on: ubuntu-latest
 
-    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Install prerequisites
+        run: |
+          python3 -m pip install -U pip wheel setuptools
+      - name: Build distribution
+        run: |
+          python3 setup.py sdist bdist_wheel
+          cd dist && sha256sum * | tee SHA256SUMS
+      - name: Install lint/test dependencies
+        run: |
+          python3 -m pip install flake8 pytest pytest-cover pytest-subtests
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --ignore F821 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Install test dependencies
+        run: |
+          python3 -m pip install -e .
+      - name: Test with pytest
+        run: |
+          pytest
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ankipandas dist ${{ github.run_number }}
+          path: ./dist
+      - name: Coveralls
+        uses: AndreMiras/coveralls-python-action@develop
+
+  test:
+    needs: [build]
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       matrix:
-        os:  [ubuntu-latest, windows-latest, macos-latest]
+        os:  [ubuntu, windows, macos]
         python-version: [3.6, 3.7, 3.8, 3.9]
+        include:
+          - python-version: 3.6
+            artifact: ankipandas-*.tar.gz
+          - python-version: 3.7
+            artifact: ankipandas-*.whl
+          - python-version: 3.8
+            artifact: ankipandas-*.whl
+          - python-version: 3.9
+            artifact: ankipandas-*.tar.gz
 
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/download-artifact@v2
+      with:
+        name: ankipandas dist ${{ github.run_number }}
+        path: ./dist
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install prerequisites
       run: |
-        python -m pip install .
-        pip install flake8 pytest pytest-cover pytest-subtests
-    - name: Lint with flake8
+        python3 -m pip install -U pip wheel
+    - name: Get artifact path
+      id: artifact
+      shell: bash -l {0}
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --ignore F821 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        cd dist
+        echo "::set-output name=path::$(ls ${{ matrix.artifact }})"
+    - name: Install package
+      run: |
+        cd dist
+        python3 -m pip install ${{ steps.artifact.outputs.path }}
+    - name: Smoke test
+      run: |
+        cd dist
+        python3 -m pip list
+        python3 -m pip check
+        python3 -c "import ankipandas"
+    - name: Install test dependencies
+      run: |
+        python3 -m pip install pytest pytest-cover pytest-subtests
     - name: Test with pytest
       run: |
-        pytest
-    - name: Coveralls
-      uses: AndreMiras/coveralls-python-action@develop
-      if: ${{ matrix.os  == 'ubuntu-latest' && matrix.python-version == 3.8 }}
+        cd dist
+        pytest --pyargs ankipandas --cov ankipandas --cov-report term-missing:skip-covered

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,3 +4,4 @@ include CHANGELOG.md
 include README.md
 include LICENSE.txt
 recursive-include ankipandas/test/data/few_basic_cards *.anki2
+recursive-include ankipandas/data *.csv

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,38 @@
 [metadata]
+name = ankipandas
+description = Load your anki database as a pandas DataFrame with just one line of code!
+url = https://github.com/klieret/ankipandas
 version = file: ankipandas/version.txt
+long_description = file: README.md
+long_description_content_type = text/markdown
+license = MIT
+license_file = LICENSE.txt
+python_requires = >=3.6
+project_urls =
+    Bug Tracker =   https://github.com/klieret/ankipandas/issues
+    Documentation = https://ankipandas.readthedocs.io/
+    Source Code =   https://github.com/klieret/ankipandas/
+keywords =
+    anki
+    pandas
+    dataframe
+classifiers =
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Topic :: Database
+    Topic :: Education
+    Topic :: Utilities
+
+[options]
+packages = find:
+include_package_data = True
+zip_safe = False
+
 
 [tool:pytest]
 addopts = --cov=ankipandas

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
+[metadata]
+version = file: ankipandas/version.txt
+
 [tool:pytest]
 addopts = --cov=ankipandas

--- a/setup.py
+++ b/setup.py
@@ -11,63 +11,22 @@ you will need administrator rights).
 # std
 import site
 import sys
-
-# noinspection PyUnresolvedReferences
-import setuptools  # see below (1)
 from pathlib import Path
 
-# (1) see https://stackoverflow.com/questions/8295644/
-# Without this import, install_requires won't work.
+# noinspection PyUnresolvedReferences
+import setuptools
 
 # Sometimes editable install fails with an error message about user site
 # being not writeable. The following line can fix that, see
 # https://github.com/pypa/pip/issues/7953
 site.ENABLE_USER_SITE = "--user" in sys.argv[1:]
 
-keywords = ["anki", "pandas", "dataframe"]
-
-description = (
-    "Load your anki database as a pandas DataFrame with just one "
-    "line of code!"
-)
-
 this_dir = Path(__file__).resolve().parent
 
-packages = setuptools.find_packages()
-
-with (this_dir / "requirements.txt").open(encoding="utf8") as rf:
-    requirements = [
+setuptools.setup(
+    install_requires=[
         req.strip()
-        for req in rf.readlines()
+        for req in (this_dir / "requirements.txt").read_text().splitlines()
         if req.strip() and not req.startswith("#")
     ]
-
-
-setuptools.setup(
-    name="ankipandas",
-    packages=packages,
-    url="https://github.com/klieret/ankipandas",
-    project_urls={
-        "Bug Tracker": "https://github.com/klieret/ankipandas/issues",
-        "Documentation": "https://ankipandas.readthedocs.io/",
-        "Source Code": "https://github.com/klieret/ankipandas/",
-    },
-    install_requires=requirements,
-    license="MIT",
-    keywords=keywords,
-    description=description,
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Topic :: Database",
-        "Topic :: Education",
-        "Topic :: Utilities",
-    ],
-    python_requires=">=3.6",
-    include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ you will need administrator rights).
 """
 
 # std
-from distutils.core import setup
 import site
 import sys
 
@@ -50,7 +49,7 @@ with (this_dir / "requirements.txt").open(encoding="utf8") as rf:
     ]
 
 
-setup(
+setuptools.setup(
     name="ankipandas",
     version=version,
     packages=packages,
@@ -80,5 +79,5 @@ setup(
         "Topic :: Utilities",
     ],
     python_requires=">=3.6",
-    include_package_data=True,
+    include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -35,12 +35,6 @@ this_dir = Path(__file__).resolve().parent
 
 packages = setuptools.find_packages()
 
-with (this_dir / "README.md").open(encoding="utf8") as fh:
-    long_description = fh.read()
-
-with (this_dir / "ankipandas" / "version.txt").open(encoding="utf8") as vf:
-    version = vf.read().strip()
-
 with (this_dir / "requirements.txt").open(encoding="utf8") as rf:
     requirements = [
         req.strip()
@@ -51,7 +45,6 @@ with (this_dir / "requirements.txt").open(encoding="utf8") as rf:
 
 setuptools.setup(
     name="ankipandas",
-    version=version,
     packages=packages,
     url="https://github.com/klieret/ankipandas",
     project_urls={
@@ -59,13 +52,10 @@ setuptools.setup(
         "Documentation": "https://ankipandas.readthedocs.io/",
         "Source Code": "https://github.com/klieret/ankipandas/",
     },
-    package_data={"ankipandas": ["anki_fields.csv", "data/*"]},
     install_requires=requirements,
     license="MIT",
     keywords=keywords,
     description=description,
-    long_description=long_description,
-    long_description_content_type="text/markdown",
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
A couple things here:
- as per #81, shows a CI approach that primarily tests the code-as-distributed
  -  an up-front `build` job (with no matrix)
    - builds the distribution artifacts
    - runs the linter
    - tests code-in-source will keep the coverage file names the same
    - uploads coverage
    - uploads the artifacts
  - the `test` matrix job:
    - downloads the artifacts
    - picks one to install (kind of annoying, because platform differences, and globs on windows)
    - runs the tests
- In working that up, moved a lot of the static (and dynamic) `setup.py` stuff to `setup.cfg`, as modern (last two years or so) setuptools does a lot more of the heavy lifting now, e.g. worrying about encodings, etc.
  - it _doesn't_ do `requirements.txt`, but it may be worth moving those to the canonical `install_requires`
  - `tests_require` could also be added... but `pip` won't install extras from a local artifact, so it still can't be a single source of truth without weird gotchas