### PR TITLE
Readme fix: convert selection back to fields_as_list in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ notes = col.notes
 selection = notes[notes.has_tag(["English"])].query("model=='LanguageModel'").copy()
 selection.fields_as_columns(inplace=True)
 selection["language"] = "English"
-col.notes.update(selection)
+col.notes.update(selection.fields_as_list())
 col.write(modify=True)
 ```
 


### PR DESCRIPTION
Currently, one of the manipulation examples in the readme doesn't work. The valueerror thrown tells you exactly what to do, but I think the example should include that fix.