### PR TITLE
Fix Issue #137: Preserve PRIMARY KEY constraints in write()

### DIFF
--- a/ankipandas/raw.py
+++ b/ankipandas/raw.py
@@ -278,9 +278,17 @@ def set_table(
     df_new = _consolidate_tables(
         df=df, df_old=df_old, mode=mode, id_column=id_column
     )
-    
-    dtype = {id_column: 'INTEGER PRIMARY KEY'} # set id_column as primary key using dtype
-    df_new.to_sql(tables_ours2anki[table], db, if_exists="replace", index=False, dtype=dtype)
+
+    dtype = {
+        id_column: "INTEGER PRIMARY KEY"
+    }  # set id_column as primary key using dtype
+    df_new.to_sql(
+        tables_ours2anki[table],
+        db,
+        if_exists="replace",
+        index=False,
+        dtype=dtype,
+    )
 
 
 class NumpyJSONEncoder(json.JSONEncoder):

--- a/ankipandas/raw.py
+++ b/ankipandas/raw.py
@@ -278,7 +278,9 @@ def set_table(
     df_new = _consolidate_tables(
         df=df, df_old=df_old, mode=mode, id_column=id_column
     )
-    df_new.to_sql(tables_ours2anki[table], db, if_exists="replace", index=False)
+    
+    dtype = {id_column: 'INTEGER PRIMARY KEY'} # set id_column as primary key using dtype
+    df_new.to_sql(tables_ours2anki[table], db, if_exists="replace", index=False, dtype=dtype)
 
 
 class NumpyJSONEncoder(json.JSONEncoder):

--- a/ankipandas/test/test_regression.py
+++ b/ankipandas/test/test_regression.py
@@ -4,14 +4,14 @@ come back later.
 
 from __future__ import annotations
 
-import tempfile
 import shutil
+import tempfile
 from pathlib import Path
 
 # ours
 from ankipandas.collection import Collection
+from ankipandas.raw import close_db, get_table, load_db, set_table
 from ankipandas.test.util import parameterized_paths
-from ankipandas.raw import load_db, close_db, get_table, set_table
 
 
 @parameterized_paths()
@@ -22,21 +22,24 @@ def test_inplace_merge_notes(db_path):
     col = Collection(db_path)
     col.cards.merge_notes(inplace=True)
 
+
 @parameterized_paths()
 def test_primary_key_constraint_preserved(db_path):
     """https://github.com/klieret/AnkiPandas/issues/137
-    
+
     Ensure PRIMARY KEY constraint is preserved when replacing table data.
     """
     # Create temporary copy of the database
-    with tempfile.NamedTemporaryFile(suffix='.anki2', delete=False) as temp_file:
+    with tempfile.NamedTemporaryFile(
+        suffix=".anki2", delete=False
+    ) as temp_file:
         temp_path = Path(temp_file.name)
         shutil.copy(db_path, temp_path)
-    
+
     db = None
     try:
         db = load_db(temp_path)
-        for table_name in ['notes', 'cards']:
+        for table_name in ["notes", "cards"]:
             table_data = get_table(db, table_name)
             set_table(db, table_data, table_name, "replace")
 
@@ -44,9 +47,13 @@ def test_primary_key_constraint_preserved(db_path):
             cursor.execute(f"PRAGMA table_info({table_name})")
             columns = cursor.fetchall()
             # PRAGMA table_info returns: (cid, name, type, notnull, dflt_value, pk)
-            has_primary_key = any(col[1] == 'id' and col[5] == 1 for col in columns)
-            
-            assert has_primary_key, f"PRIMARY KEY constraint was lost on {table_name} table"
+            has_primary_key = any(
+                col[1] == "id" and col[5] == 1 for col in columns
+            )
+
+            assert (
+                has_primary_key
+            ), f"PRIMARY KEY constraint was lost on {table_name} table"
     finally:
         if db is not None:
             close_db(db)

--- a/ankipandas/test/test_regression.py
+++ b/ankipandas/test/test_regression.py
@@ -4,9 +4,14 @@ come back later.
 
 from __future__ import annotations
 
+import tempfile
+import shutil
+from pathlib import Path
+
 # ours
 from ankipandas.collection import Collection
 from ankipandas.test.util import parameterized_paths
+from ankipandas.raw import load_db, close_db, get_table, set_table
 
 
 @parameterized_paths()
@@ -16,3 +21,33 @@ def test_inplace_merge_notes(db_path):
     """
     col = Collection(db_path)
     col.cards.merge_notes(inplace=True)
+
+@parameterized_paths()
+def test_primary_key_constraint_preserved(db_path):
+    """https://github.com/klieret/AnkiPandas/issues/137
+    
+    Ensure PRIMARY KEY constraint is preserved when replacing table data.
+    """
+    # Create temporary copy of the database
+    with tempfile.NamedTemporaryFile(suffix='.anki2', delete=False) as temp_file:
+        temp_path = Path(temp_file.name)
+        shutil.copy(db_path, temp_path)
+    
+    db = None
+    try:
+        db = load_db(temp_path)
+        for table_name in ['notes', 'cards']:
+            table_data = get_table(db, table_name)
+            set_table(db, table_data, table_name, "replace")
+
+            cursor = db.cursor()
+            cursor.execute(f"PRAGMA table_info({table_name})")
+            columns = cursor.fetchall()
+            # PRAGMA table_info returns: (cid, name, type, notnull, dflt_value, pk)
+            has_primary_key = any(col[1] == 'id' and col[5] == 1 for col in columns)
+            
+            assert has_primary_key, f"PRIMARY KEY constraint was lost on {table_name} table"
+    finally:
+        if db is not None:
+            close_db(db)
+        temp_path.unlink(missing_ok=True)


### PR DESCRIPTION
When using `pandas.to_sql(if_exists="replace")`, PRIMARY KEY constraints are lost from SQLite tables. [This breaks Anki's synchronization mechanism between devices.](https://github.com/klieret/AnkiPandas/issues/137#issuecomment-1756625536)

### Fix
- Reassign `id_column` to be the PRIMARY KEY using `dtype={'id_column': 'INTEGER PRIMARY KEY'}` parameter when calling `pandas.to_sql()` in `raw.py`
- Added simple regression tests covering both `notes` and `cards` tables

### Testing
- All existing tests pass
- New regression test `test_primary_key_constraint_preserved` validates the fix